### PR TITLE
fix: internal server error on non-ui endpoint

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -4,8 +4,9 @@ use axum::{
     extract::{Host, Path, State},
 };
 use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 
-use crate::{repository::DestinationPaymentAddress, AppState};
+use crate::AppState;
 use crate::service::RegisterResponse;
 
 pub async fn list_domains_handler(
@@ -36,14 +37,14 @@ pub async fn get_lnaddr_manifest_handler(
 pub async fn get_lnaddr_handler(
     State(state): State<AppState>,
     Path((domain, username)): Path<(String, String)>,
-) -> Result<Json<DestinationPaymentAddress>, axum::http::StatusCode> {
+) -> Result<Json<Value>, axum::http::StatusCode> {
     state
         .service
         .get_destination(&domain, &username)
         .await
         .map_err(|_| axum::http::StatusCode::INTERNAL_SERVER_ERROR)?
         .ok_or(axum::http::StatusCode::NOT_FOUND)
-        .map(Json)
+        .map(|d| Json(json!({ "url": d.url() })))
 }
 
 pub async fn register_lnaddr_handler(

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -25,6 +25,7 @@ pub trait IPaymentAddressRepository {
     ) -> Result<()>;
 }
 
+#[derive(Debug)]
 pub struct PaymentAddress {
     pub username: String,
     pub domain: String,


### PR DESCRIPTION
After registering `hello@localhost` using the UI, I was surprised to find that

```
curl http://localhost:8080/lnaddress/localhost/hello
```

would give me a 500 internal server. After debugging a bit, the root cause seems to me that `Lnurl` is not `Serializable`

```
#[derive(Debug, PartialEq, Clone, Ord, PartialOrd, Eq, Hash)]
pub struct LnUrl {
    pub url: String,
}
```

so this would error when trying to map to `Json`. This PR patches this by explicitly manipulating the returned payment code and manually constructing the json.