### PR TITLE
feat: add remove payment address endpoint

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -4,7 +4,7 @@ use axum::{
     extract::{Host, Path, State},
 };
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::AppState;
 use crate::service::RegisterResponse;
@@ -59,9 +59,33 @@ pub async fn register_lnaddr_handler(
         .map(Json)
 }
 
+pub async fn remove_lnaddr_handler(
+    State(state): State<AppState>,
+    Json(payload): Json<RemoveRequest>,
+) -> Result<axum::http::StatusCode, axum::http::StatusCode> {
+    state
+        .service
+        .remove_lnaddr(
+            &payload.domain,
+            &payload.username,
+            &payload.authentication_token,
+        )
+        .await
+        .map_err(|_| axum::http::StatusCode::UNAUTHORIZED)?;
+
+    Ok(axum::http::StatusCode::NO_CONTENT)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegisterRequest {
     pub domain: String,
     pub username: String,
     pub lnurl: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RemoveRequest {
+    pub domain: String,
+    pub username: String,
+    pub authentication_token: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,12 @@
 use anyhow::Result;
 use api::{
     get_lnaddr_handler, get_lnaddr_manifest_handler, list_domains_handler, register_lnaddr_handler,
+    remove_lnaddr_handler,
 };
 use axum::{
     Router,
     response::IntoResponse,
-    routing::{get, post},
+    routing::{get, post, delete},
 };
 use config::Config;
 use repository::pg::PgPaymentAddressRepository;
@@ -44,6 +45,7 @@ pub async fn serve(config: &Config) -> Result<()> {
         .route("/domains", get(list_domains_handler))
         .route("/lnaddress/:domain/:username", get(get_lnaddr_handler))
         .route("/lnaddress/register", post(register_lnaddr_handler))
+        .route("/lnaddress/remove", delete(remove_lnaddr_handler))
         .route(
             "/.well-known/lnurlp/:username",
             get(get_lnaddr_manifest_handler),

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -2,7 +2,7 @@ pub mod pg;
 
 use std::{fmt::Display, str::FromStr, sync::Arc, time::SystemTime};
 
-use anyhow::{ensure, Result};
+use anyhow::{Result, ensure};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
@@ -23,6 +23,13 @@ pub trait IPaymentAddressRepository {
         destination: DestinationPaymentAddress,
         authentication_token: &str,
     ) -> Result<()>;
+
+    async fn remove_payment_address(
+        &self,
+        domain: &str,
+        username: &str,
+        authentication_token: &str,
+    ) -> Result<()>;
 }
 
 #[derive(Debug)]
@@ -41,7 +48,7 @@ pub enum DestinationPaymentAddress {
     Lnurl(lnurl::lnurl::LnUrl),
     LnAddress {
         user: String,
-        domain: String,
+        domain: String
     },
 }
 

--- a/src/service/direct.rs
+++ b/src/service/direct.rs
@@ -83,4 +83,15 @@ impl ILnaddrService for DirectLnaddrService {
             authentication_token,
         })
     }
+
+    async fn remove_lnaddr(
+        &self,
+        domain: &str,
+        username: &str,
+        authentication_token: &str,
+    ) -> Result<()> {
+        self.repo
+            .remove_payment_address(domain, username, authentication_token)
+            .await
+    }
 }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -29,6 +29,13 @@ pub trait ILnaddrService {
         username: &str,
         destination: &str,
     ) -> Result<RegisterResponse>;
+
+    async fn remove_lnaddr(
+        &self,
+        domain: &str,
+        username: &str,
+        authentication_token: &str,
+    ) -> Result<()>;
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,5 +1,6 @@
 use crate::AppState;
 use crate::api::RegisterRequest;
+use crate::repository::DestinationPaymentAddress;
 use axum::{
     Form,
     extract::Path,
@@ -10,7 +11,6 @@ use maud::{DOCTYPE, Markup, html};
 use qrcode::QrCode;
 use qrcode::render::svg;
 use serde::Deserialize;
-use crate::repository::DestinationPaymentAddress;
 
 #[derive(Deserialize)]
 pub struct RegisterForm {


### PR DESCRIPTION
Adds the ability to remove a payment address. Endpoint requires authentication token so that only the current holder of the payment address can delete it.